### PR TITLE
Display relevant image for each athlete

### DIFF
--- a/src/pages/athlete/athlete.html
+++ b/src/pages/athlete/athlete.html
@@ -9,7 +9,7 @@
   <ion-content>
     <ng-container *ngIf="athlete">
       <div class="athlete">
-        <img src="././assets/imgs/dummy_profile_image.jpg" class="img-circle">
+        <img src="{{ athlete.attributes.image }}" class="img-circle">
         <h2>{{ athlete.attributes.name }} ({{ athlete.attributes.age }})</h2>
         <p>Home Mountain / {{ athlete.attributes.home }}</p>
         <h1>RACES : {{ athlete.attributes.starttime }}</h1>

--- a/src/pages/athletes/athletes.html
+++ b/src/pages/athletes/athletes.html
@@ -10,7 +10,7 @@
   <ion-list>
     <ion-item *ngFor="let athlete of athletes" (click)="launchAthletePage(athlete.id)">
       <ion-avatar item-start>
-        <img src="././assets/imgs/thumbnail-totoro.png">
+        <img src="{{ athlete.attributes.image }}">
       </ion-avatar>
       <h2>{{ athlete.attributes.name }}</h2>
       <p>{{ athlete.attributes.home }}</p>


### PR DESCRIPTION
#### PT Story: https://www.pivotaltracker.com/story/show/156593043
#### Description
Changes proposed in this pull request:
* Adds and displays images stored on AWS to relevant athlete on index- and show-page

#### What I have learned working on this feature: 
* Working with Ionic and remote API's

#### Screenshots:
<img width="1680" alt="skarmavbild 2018-04-09 kl 14 09 07" src="https://user-images.githubusercontent.com/25644242/38497079-1e8dfa92-3c00-11e8-85a7-925c6d0f5922.png">