### PR TITLE
Style results and athlete-page the same way

### DIFF
--- a/src/pages/athletes/athletes.html
+++ b/src/pages/athletes/athletes.html
@@ -12,13 +12,19 @@
     <ion-refresher-content></ion-refresher-content>
   </ion-refresher>
 
-  <ion-list>
-    <ion-item *ngFor="let athlete of athletes" (click)="launchAthletePage(athlete.id)">
-      <ion-avatar item-start>
-        <img src="{{ athlete.attributes.image }}">
-      </ion-avatar>
-      <h2>{{ athlete.attributes.name }}</h2>
-      <p>{{ athlete.attributes.home }}</p>
-    </ion-item>
-  </ion-list>
+  <ng-container>
+    <ion-list>
+      <h1 class="title">Skiers</h1>
+      <ion-item *ngFor="let athlete of athletes" (click)="launchAthletePage(athlete.id)">
+        <ion-avatar item-start>
+          <img src="{{ athlete.attributes.image }}">
+        </ion-avatar>
+        <h2 class="name">{{ athlete.attributes.name }}</h2>
+        <p>{{ athlete.attributes.home }}</p>
+        <p>Start-nr:
+          <strong>{{ athlete.attributes.starttime }}</strong>
+        </p>
+      </ion-item>
+    </ion-list>
+  </ng-container>
 </ion-content>

--- a/src/pages/athletes/athletes.scss
+++ b/src/pages/athletes/athletes.scss
@@ -1,11 +1,21 @@
 page-athletes {
     .item-md ion-avatar ion-img, .item-md ion-avatar img {
-        width: 55px;
-        height: 55px;
+        width: 68px;
+        height: 68px;
     }
 
     .item-ios ion-avatar img {
-        width: 55px;
-        height: 55px;
+        width: 68px;
+        height: 68px;
+    }
+
+    h1.title {
+        text-align: left;
+        margin-left: 20px; 
+      }
+
+     h2.name {
+        font-size: 2.8vh;
+        font-weight: 400;
     }
 }

--- a/src/pages/athletes/athletes.ts
+++ b/src/pages/athletes/athletes.ts
@@ -36,4 +36,12 @@ export class AthletesPage {
       this.navCtrl.push(AthletePage, { athlete_id: id });
   }
 
+  ionViewDidLeave() {
+    this.athletesProvider
+      .all()
+      .subscribe(athletes => {
+        this.athletes = athletes.data;
+     });
+  }
+
 }

--- a/src/pages/athletes/athletes.ts
+++ b/src/pages/athletes/athletes.ts
@@ -37,6 +37,7 @@ export class AthletesPage {
   }
 
   ionViewDidLeave() {
+    console.log('Hes leaving');
     this.athletesProvider
       .all()
       .subscribe(athletes => {

--- a/src/pages/results/results.html
+++ b/src/pages/results/results.html
@@ -1,60 +1,91 @@
 <ion-header>
-  <ion-navbar>
-    <ion-title>
-      <img src="././assets/imgs/logo-large.png">
-    </ion-title>
-  </ion-navbar>
-</ion-header>
-
-<ion-content>
-
-  <ion-refresher (ionRefresh)="doRefresh($event)">
-    <ion-refresher-content></ion-refresher-content>
-  </ion-refresher>
-
-  <div *ngIf="finalStanding == true" class="results">
-    <ion-list>
-      <h1>Final Standings</h1>
-      <ion-item *ngFor="let result of validResults| slice:0:1; let i = index" [attr.data-index]="i">
-        <h1 class="icon"> <ion-icon class="goldTrophy" name="trophy"></ion-icon> </h1>
-        <h2>{{ result.attributes.athletename }}</h2>
-        <p>Final Score: <strong>{{ result.attributes.score.toFixed(1) }}</strong></p>
-        <p>Number of Votes: <strong>{{ result.attributes.numberofvotes }}</strong></p>
-      </ion-item>
-      <ion-item *ngFor="let result of validResults| slice:1:2; let i = index" [attr.data-index]="i">
-        <h1 class="icon"><ion-icon class="silverTrophy" name="trophy"></ion-icon></h1>
-        <h2>{{ result.attributes.athletename }}</h2>
-        <p>Final Score: <strong>{{ result.attributes.score.toFixed(1) }}</strong></p>
-        <p>Number of Votes: <strong>{{ result.attributes.numberofvotes }}</strong></p>
-      </ion-item>
-      <ion-item *ngFor="let result of validResults| slice:2:3; let i = index" [attr.data-index]="i">
-        <h1 class="icon"><ion-icon class="bronseTrophy" name="trophy"></ion-icon></h1>
-        <h2>{{ result.attributes.athletename }}</h2>
-        <p>Final Score: <strong>{{ result.attributes.score.toFixed(1) }}</strong></p>
-        <p>Number of Votes: <strong>{{ result.attributes.numberofvotes }}</strong></p>
-      </ion-item>
-      <ion-item *ngFor="let result of validResults| slice:3:10000; let i = index" [attr.data-index]="i">
-        <h1 class="icon number"> {{ i + 4}} </h1>
-        <h2>{{ result.attributes.athletename }}</h2>
-        <p>Final Score: <strong>{{ result.attributes.score.toFixed(1) }}</strong></p>
-        <p>Number of Votes: <strong>{{ result.attributes.numberofvotes }}</strong></p>
-      </ion-item>
-    </ion-list>
-    
-    <ion-list>
-      <h5> Insufficient Scores </h5>
-      <ion-item *ngFor="let result of invalidResults">
-        <h1 class="icon x"> X </h1>
-        <h2>{{ result.attributes.athletename }}</h2>
-        <p>Final Score: <strong>{{ result.attributes.score.toFixed(1) }}</strong></p>
-        <p>Number of Votes: <strong>{{ result.attributes.numberofvotes }}</strong></p>
-      </ion-item>
-    </ion-list>
-  </div>
-
-  <div *ngIf="finalStanding == false" class="results">
-    <h3>Results Coming Soon</h3>
-    <p>"Remember, boys, no points for second place."</p>
-    <p>"It takes a lot more than just fancy skiing to win this."</p>
-  </div>
-</ion-content>
+    <ion-navbar>
+      <ion-title>
+        <img src="././assets/imgs/logo-large.png">
+      </ion-title>
+    </ion-navbar>
+  </ion-header>
+  
+  <ion-content>
+  
+    <ion-refresher (ionRefresh)="doRefresh($event)">
+      <ion-refresher-content></ion-refresher-content>
+    </ion-refresher>
+  
+    <ng-container class="results" *ngIf="resultsPublished==true">
+      <ion-list>
+        <h1 class="title">Final Standings</h1>
+        <ion-item *ngFor="let result of validResults| slice:0:1; let i = index" [attr.data-index]="i">
+          <ion-avatar item-start>
+            <ion-icon class="goldTrophy" name="trophy"></ion-icon>
+          </ion-avatar>
+          <h2 class="results">{{ result.attributes.athletename }}</h2>
+          <p>Final Score:
+            <strong>{{ result.attributes.score.toFixed(1) }}</strong>
+          </p>
+          <p>Number of Votes:
+            <strong>{{ result.attributes.numberofvotes }}</strong>
+          </p>
+        </ion-item>
+        <ion-item *ngFor="let result of validResults| slice:1:2; let i = index" [attr.data-index]="i">
+          <ion-avatar item-start>
+            <ion-icon class="silverTrophy" name="trophy"></ion-icon>
+          </ion-avatar>
+          <h2 class="results">{{ result.attributes.athletename }}</h2>
+          <p>Final Score:
+            <strong>{{ result.attributes.score.toFixed(1) }}</strong>
+          </p>
+          <p>Number of Votes:
+            <strong>{{ result.attributes.numberofvotes }}</strong>
+          </p>
+        </ion-item>
+        <ion-item *ngFor="let result of validResults| slice:2:3; let i = index" [attr.data-index]="i">
+          <ion-avatar item-start>
+            <ion-icon class="bronseTrophy" name="trophy"></ion-icon>
+          </ion-avatar>
+          <h2 class="results">{{ result.attributes.athletename }}</h2>
+          <p>Final Score:
+            <strong>{{ result.attributes.score.toFixed(1) }}</strong>
+          </p>
+          <p>Number of Votes:
+            <strong>{{ result.attributes.numberofvotes }}</strong>
+          </p>
+        </ion-item>
+        <ion-item *ngFor="let result of validResults| slice:3:10000; let i = index" [attr.data-index]="i">
+          <ion-avatar item-start>
+            <h1 class="number icon"> {{ i + 4}} </h1>
+          </ion-avatar>
+          <h2 class="results">{{ result.attributes.athletename }}</h2>
+          <p>Final Score:
+            <strong>{{ result.attributes.score.toFixed(1) }}</strong>
+          </p>
+          <p>Number of Votes:
+            <strong>{{ result.attributes.numberofvotes }}</strong>
+          </p>
+        </ion-item>
+      </ion-list>
+  
+      <ion-list>
+        <h5 class="subtitle"> Insufficient Scores </h5>
+        <ion-item *ngFor="let result of invalidResults">
+          <ion-avatar item-start>
+            <h1 class="x icon"> X </h1>
+          </ion-avatar>
+          <h2 class="results">{{ result.attributes.athletename }}</h2>
+          <p>Final Score:
+            <strong>{{ result.attributes.score.toFixed(1) }}</strong>
+          </p>
+          <p>Number of Votes:
+            <strong>{{ result.attributes.numberofvotes }}</strong>
+          </p>
+        </ion-item>
+      </ion-list>
+    </ng-container>
+  
+    <ng-container padding class="results" *ngIf="resultsPublished==false">
+      <h3>Results are coming soon</h3>
+      <p>"Remember, boys, no points for second place."</p>
+      <p>"It takes a lot more than just fancy skiing to win this."</p>
+    </ng-container>
+  
+  </ion-content>

--- a/src/pages/results/results.scss
+++ b/src/pages/results/results.scss
@@ -1,16 +1,26 @@
 page-results {
-  .results h1 {
+  h1.results {
     text-align: center;
   }
 
-  .results h2 {
-    font-size: 2.5vh;
+  h2.results {
+    font-size: 2.8vh;
     font-weight: 400;
   }
 
-  .results h5 {
+  h5.results {
     font-size: 3.0vh;
     text-align: center;
+  }
+
+  h1.title {
+    text-align: left;
+    margin-left: 20px; 
+  }
+
+  h5.subtitle {
+    text-align: left;
+    margin-left: 20px;
   }
 
   .icon {
@@ -19,10 +29,10 @@ page-results {
     -moz-border-radius: 1.2em;
     -webkit-border-radius: 1.2em;
     width: 2em;
+    text-align: center;
     line-height: 10vh;
     font-size: 5vh;
     float: left;
-    margin-right: 20px;
   }
 
   .goldTrophy {
@@ -39,14 +49,12 @@ page-results {
 
   h1.x {
     color: #fff;
-    font-size: 5vh;
     width: 2em;
     background: #ff689d;
   }
 
   h1.number {
     color: #fff;
-    font-size: 5vh;
     width: 2em;
     background: #336699;
   }


### PR DESCRIPTION
#### PT Story: https://www.pivotaltracker.com/story/show/156719421
#### Description
Changes proposed in this pull request:
* Updates the styling of athlete and results-page to share the same look

#### What I have learned working on this feature: 
* Working with SCSS

#### Screenshots:
<img width="1680" alt="skarmavbild 2018-04-12 kl 12 57 40" src="https://user-images.githubusercontent.com/25644242/38673265-1d3b4930-3e51-11e8-93a7-d7cf507cd637.png">